### PR TITLE
Chore/sample

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,26 +70,42 @@ class _MyHomePageState extends State<MyHomePage> {
             style: Theme.of(context).textTheme.headline4,
           ),
           Container(
-            margin: const EdgeInsets.all(30),
-            padding: const EdgeInsets.all(20),
-            width: 200,
-            height: 100,
-            decoration: BoxDecoration(
-              // 枠線
-              border: Border.all(color: Colors.green, width: 5),
-
-              // 角丸
-              borderRadius: BorderRadius.circular(8),
-
-              // コンテナのカラー
-              color: Colors.pink[300],
-
-              // 背景画像
-              image: const DecorationImage(
-                image: NetworkImage('https://placehold.jp/100x100.png'),
+            color: Colors.blue,
+            child: Container(
+              margin: const EdgeInsets.all(30),
+              padding: const EdgeInsets.all(20),
+              width: 200,
+              height: 80,
+              decoration: BoxDecoration(
+                // 枠線
+                border: Border.all(
+                  color: Colors.green,
+                  width: 5,
+                ),
+                // 角丸
+                borderRadius: BorderRadius.circular(8),
+                // コンテナのカラー
+                color: Colors.pink[300],
+                // 背景画像
+                image: const DecorationImage(
+                  image: NetworkImage('https://placehold.jp/100x100.png'),
+                ),
+              ),
+              child: const Text(
+                'TextAlign.right',
+                textAlign: TextAlign.right,
               ),
             ),
-            child: const Text('TextAlign.right', textAlign: TextAlign.right),
+          ),
+          ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: 320.0, maxHeight: 64.0),
+            child: Container(
+              color: Colors.red,
+              child: const FittedBox(
+                fit: BoxFit.fitWidth,
+                child: Text("テキストテキストテキストテキストテキストテキスト"),
+              ),
+            ),
           ),
           Container(
             height: 125,

--- a/lib/stateful_page.dart
+++ b/lib/stateful_page.dart
@@ -20,6 +20,31 @@ class _NewWidgetState extends State<StatefulPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false, // デフォルトの戻るアイコンを削除
+        // leading: Icon(Icons.arrow_back_ios), // これだとただのアイコン設置。クリックとかはできない。
+        leadingWidth: 85,
+        leading: TextButton(
+          child: const Text(
+            '戻りたい...',
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+              fontSize: 12.0,
+            ),
+          ),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: Text('Stateful Widget'),
+        actions: [
+          IconButton(
+            onPressed: () {},
+            icon: Icon(Icons.favorite),
+          ),
+          IconButton(
+            onPressed: () {},
+            icon: Icon(Icons.more_vert),
+          ),
+        ],
       ),
       body: Center(
         child: Center(


### PR DESCRIPTION
[Widget で UI をつくる](https://www.flutter-study.dev/widgets/about-widget)

- コンテナサイズ、余白とか 64514c96d2bbada61c633f8c2b4319b196bbe122
- AppBar 周り 19bb97be16ea393b8f406b07d9a038c371be86b1

参考
[AppBarのleadingにテキストボタンを追加したい - Qiita](https://qiita.com/itsukiss/items/61d76db6b74b75eca8a2)
[【Flutter】AppBarの戻るアイコン（leading）をカスタマイズしてみる - Qiita](https://qiita.com/sunagakuuun/items/1c6fb0dd0e50d8e8deb6)
[[Flutter]AppBarの戻るボタン(back button)にイベント(event)を追加するには？ | ちょげぶろぐ](https://www.choge-blog.com/programming/flutterappbar%E3%81%AE%E6%88%BB%E3%82%8B%E3%83%9C%E3%82%BF%E3%83%B3%E3%81%AB%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%99%E3%82%8B%E3%81%AB%E3%81%AF%EF%BC%9F/)
